### PR TITLE
footer links set to open in a new tab

### DIFF
--- a/src/pages/Popup/Popup.jsx
+++ b/src/pages/Popup/Popup.jsx
@@ -209,7 +209,7 @@ class Popup extends Component {
               size="small"
               aria-label="delete"
               onClick={(e) => {
-                chrome.tabs.update({
+                chrome.tabs.create({
                   url: 'https://github.com/architec/mistake',
                 });
                 e.preventDefault();
@@ -224,7 +224,7 @@ class Popup extends Component {
               size="small"
               aria-label="delete"
               onClick={(e) => {
-                chrome.tabs.update({
+                chrome.tabs.create({
                   url: 'https://leetcode.com/discuss/general-discussion/460599/blind-75-leetcode-questions',
                 });
                 e.preventDefault();
@@ -237,7 +237,7 @@ class Popup extends Component {
               size="small"
               aria-label="delete"
               onClick={(e) => {
-                chrome.tabs.update({
+                chrome.tabs.create({
                   url: 'https://leetcode.com/tag/dynamic-programming/discuss/1050391/Must-do-Dynamic-programming-Problems-Category-wise',
                 });
                 e.preventDefault();


### PR DESCRIPTION
Fixes #95 

The links in the footer (GitHub repo, blind 75 and DP problems) will now open in a new tab instead of replacing the existing tab in which the chrome extension popup has been opened.